### PR TITLE
Make inner shadow follow mask

### DIFF
--- a/src/scss/modules/_hole.scss
+++ b/src/scss/modules/_hole.scss
@@ -9,7 +9,13 @@
   // Circular mask - position set dynamically via JavaScript
   // clip-path is set in hole.js for interactivity
 
-  // Inner shadow projected by the mask - fixed at bottom right, not affected by scroll
+  // CSS custom properties for mask position (set by JavaScript in hole.js)
+  // Default values match initial mask position (bottom-right corner)
+  --mask-x: 100%;
+  --mask-y: 100%;
+  --mask-radius-num: 40;
+
+  // Inner shadow projected by the mask - follows mask position via CSS custom properties
   &::before {
     content: '';
     position: absolute;
@@ -17,16 +23,18 @@
     left: 0;
     width: 100%;
     height: 100%;
-    // Radial gradient creates circular shadow effect fixed at bottom right (100% 100%)
+    // Radial gradient creates circular shadow effect that follows the mask
+    // Position uses --mask-x and --mask-y set by JavaScript
+    // Radius uses --mask-radius-num (in vmin) set by JavaScript
     background: radial-gradient(
-      circle at 100% 100%,
+      circle at var(--mask-x, 100%) var(--mask-y, 100%),
       transparent 0%,
-      transparent calc(40vmin - 80px),
-      rgba(0, 0, 0, 0.1) calc(40vmin - 60px),
-      rgba(0, 0, 0, 0.2) calc(40vmin - 40px),
-      rgba(0, 0, 0, 0.4) calc(40vmin - 20px),
-      rgba(0, 0, 0, 0.6) calc(40vmin - 10px),
-      rgba(0, 0, 0, 0.8) 40vmin,
+      transparent calc(var(--mask-radius-num, 40) * 1vmin - 80px),
+      rgba(0, 0, 0, 0.1) calc(var(--mask-radius-num, 40) * 1vmin - 60px),
+      rgba(0, 0, 0, 0.2) calc(var(--mask-radius-num, 40) * 1vmin - 40px),
+      rgba(0, 0, 0, 0.4) calc(var(--mask-radius-num, 40) * 1vmin - 20px),
+      rgba(0, 0, 0, 0.6) calc(var(--mask-radius-num, 40) * 1vmin - 10px),
+      rgba(0, 0, 0, 0.8) calc(var(--mask-radius-num, 40) * 1vmin),
       rgba(0, 0, 0, 0.9) 100%
     );
     pointer-events: none;


### PR DESCRIPTION
Update inner shadow to follow the mask's position when dragged.

The inner shadow's radial gradient was previously hardcoded to a fixed `100% 100%` position, preventing it from moving with the dynamically positioned mask. This PR updates the SCSS to use CSS custom properties (`--mask-x`, `--mask-y`, `--mask-radius-num`) for the shadow's position and radius, which are already updated by JavaScript during drag events.

---
<a href="https://cursor.com/background-agent?bcId=bc-4670238e-0359-47f0-b8f5-33acfc3ae928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4670238e-0359-47f0-b8f5-33acfc3ae928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inner shadow gradient now tracks the mask’s dynamic position and radius using CSS custom properties.
> 
> - **Styles** (`src/scss/modules/_hole.scss`):
>   - Add CSS custom properties: `--mask-x`, `--mask-y`, `--mask-radius-num` with defaults.
>   - Update `&::before` radial-gradient to use these properties for position and radius so the inner shadow follows the mask.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f364de40857f221dd84c1355e6a54779e486dd13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->