### PR TITLE
Limit canvas code font size to 18px

### DIFF
--- a/src/scripts/modules/hole.js
+++ b/src/scripts/modules/hole.js
@@ -248,9 +248,9 @@ class Hole {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
       // Calculate font size from vmin (2vmin = 2% of smaller viewport dimension)
-      // Ensure minimum font size of 14px
+      // Ensure minimum font size of 14px and maximum of 18px
       const vmin = Math.min(window.innerWidth, window.innerHeight) / 100;
-      const fontSize = Math.max(14, 2 * vmin);
+      const fontSize = Math.min(18, Math.max(14, 2 * vmin));
 
       // Set text rendering properties
       ctx.font = `${fontSize}px monospace`;


### PR DESCRIPTION
Cap the font size for code text rendered on the canvas at 18px.

---
<a href="https://cursor.com/background-agent?bcId=bc-af1d062c-66ae-4957-a112-c582a5aa41c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af1d062c-66ae-4957-a112-c582a5aa41c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caps the canvas-rendered code font size at a maximum of 18px (minimum remains 14px).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c43c32dfcf9ac8ecd5a80949db18a49ffb23678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->