### PR TITLE
Adjust light mode background colors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ A permanently temporal business vcard site for xbonell.com - a personal portfoli
 
 ### Project Details
 - **Project Name**: xbonell-vcard
-- **Version**: 1.9.4
+- **Version**: 1.9.5
 - **Type**: Personal vCard Website
 - **Author**: Xavier Bonell Iturbe
 - **Domain**: xbonell.com
@@ -88,6 +88,12 @@ The site supports multiple languages:
 - Replaced gulp-rev-rewrite with custom fs-based approach due to Gulp 5 incompatibility
 - Asset references in both HTML and JS files are now correctly rewritten with hashed paths
 - Removed gulp-rev-rewrite dependency from package.json
+
+### Version 1.9.5 Updates
+- Adjusted light mode theme background colors for improved visual hierarchy
+- `--color-backstage` now uses the previous `--color-bg` value (`#e9e7e3`)
+- `--color-bg` is now 10% lighter (`#ebe9e6`) using Sass `color.scale()` function
+- Provides better contrast between the main background and backstage (hole) background in light mode
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A permanently temporal business vcard site for [xbonell.com](http://xbonell.com)
 
 This project is the source code for the personal vCard website of xbonell.com. It serves as a digital business card, providing a concise and elegant way to share professional information, contact details, and links.
 
-**Current Version**: 1.9.4
+**Current Version**: 1.9.5
 
 ## Features
 
@@ -114,6 +114,7 @@ The build system uses Gulp with the following features:
 
 ## Recent Updates
 
+- **Version 1.9.5**: Adjusted light mode theme background colors for improved visual hierarchy (`--color-bg` is now 10% lighter, previous value moved to `--color-backstage`)
 - **Version 1.9.4**: Fixed asset URL rewriting in hashAssets gulp task for both HTML and JS files, replaced gulp-rev-rewrite with custom fs-based approach for Gulp 5 compatibility
 - **Version 1.9.3**: iOS Safari compatibility fixes (dvh viewport, GPU acceleration, debounced resize), centralized browserslist, Yarn 4.12.0
 - **Version 1.9.1**: Refactored hole module with full viewport logo mask, theme-aware inversion, and improved parallax scrolling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xbonell-vcard",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Source for the xbonell.com vcard site.",
   "main": "gulpfile.babel.js",
   "scripts": {

--- a/src/scss/utils/_variables.scss
+++ b/src/scss/utils/_variables.scss
@@ -45,8 +45,8 @@ $color-yellow: #f4c430;
 
 // Light theme
 [data-theme="light"] {
-  --color-backstage: #d2cec6;
-  --color-bg: #e9e7e3;
+  --color-backstage: #e9e7e3;
+  --color-bg: #{color.scale(#e9e7e3, $lightness: 10%)};
   --color-text: #2c3e50;
   --color-grey: #6c757d;
   --color-shadow: rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Update light mode theme colors for `--color-backstage` and `--color-bg`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9008ceae-21be-4ea4-8a04-3046b9f09c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9008ceae-21be-4ea4-8a04-3046b9f09c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Light theme backgrounds adjusted for better contrast and version bumped to 1.9.5 with docs updated.
> 
> - **Styles (SCSS)**:
>   - Update light theme variables in `src/scss/utils/_variables.scss`:
>     - `--color-backstage` set to previous `--color-bg` (`#e9e7e3`).
>     - `--color-bg` lightened by 10% via `color.scale()` for improved contrast.
> - **Docs/Metadata**:
>   - Bump version to `1.9.5` in `package.json`, `README.md`, and `AGENTS.md`.
>   - Add 1.9.5 notes to Recent Updates sections describing the light mode background changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fdbb667861c134d44a95494a8dbd4ef32d87459. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->